### PR TITLE
updated gitignore to ignore documentation generated on test installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ compiled
 /doc
 /planet-docs
 /zguide
+net/zmq/doc


### PR DESCRIPTION
I noticed that .gitignore does not ignore documentation generated using `raco pkg install --link <package>'.  This PR updates the gitignore
