### PR TITLE
Zmq proxy

### DIFF
--- a/net/zmq.rkt
+++ b/net/zmq.rkt
@@ -20,19 +20,19 @@
   (define external
     (get-ffi-obj 'internal zmq-lib type)))
 
-(define-syntax-parameter current-zmq-fun #f) 
+(define-syntax-parameter current-zmq-fun #f)
 (define-syntax-rule (define-zmq (external internal)
                       (-> [name name/c] ...
                           result/c)
                       type)
   (begin
-    (splicing-syntax-parameterize 
+    (splicing-syntax-parameterize
      ([current-zmq-fun 'external])
      (define-zmq* (external internal) type))
     (provide/doc
      [proc-doc/names
       external (c:-> name/c ... result/c)
-      (name ...) @{An FFI binding for 
+      (name ...) @{An FFI binding for
                    @link[(format "http://api.zeromq.org/~a.html" 'internal)]{@symbol->string['internal]}.}])))
 
 ;;
@@ -51,7 +51,7 @@
 
 (define-syntax-rule (define-zmq-symbols _type type?
                       [sym = num] ...)
-  (begin 
+  (begin
     (define _type
       (_enum (append '[sym = num] ...) _int))
     (define type?
@@ -62,7 +62,7 @@
       @{A contract for the symbols @racket['(sym ...)]}])))
 (define-syntax-rule (define-zmq-bitmask _base _type type?
                       [sym = num] ...)
-  (begin 
+  (begin
     (define _type
       (_bitmask (append '[sym = num] ...) _base))
     (define type-symbol?
@@ -116,7 +116,7 @@
 
 (require (for-syntax racket/base syntax/parse unstable/syntax))
 (define-syntax (define-cvector-type stx)
-  (syntax-parse 
+  (syntax-parse
    stx
    [(_ name:id _type:expr size:number)
     (with-syntax
@@ -127,7 +127,7 @@
         (define-cstruct name
           ([field _type]
            ...))))]))
-    
+
 (define-cvector-type _ucharMAX _uchar 30)
 (define-cstruct _msg
   ([content _pointer]
@@ -151,7 +151,7 @@
  [proc-doc/names
   poll-item? (c:-> any/c boolean?)
   (x) @{Determines if @racket[x] is a ZeroMQ poll item.}]
- [proc-doc/names 
+ [proc-doc/names
   make-poll-item (c:-> socket? exact-nonnegative-integer? poll-status? poll-status?
                        poll-item?)
   (socket fd events revents)
@@ -159,7 +159,7 @@
  [proc-doc/names
   poll-item-revents (c:-> poll-item? poll-status?)
   (pi) @{Extracts the @litchar{revents} field from a poll item structure.}])
-  
+
 ;; Errors
 (define-zmq*
   [errno zmq_errno]
@@ -175,7 +175,7 @@
        (error '#,(syntax-parameter-value #'current-zmq-fun) (strerro (errno))))]))
 
 ;; Context
-(define-zmq 
+(define-zmq
   [context zmq_init]
   (-> [io_threads exact-nonnegative-integer?]
       context?)
@@ -326,10 +326,10 @@
      (with-syntax ([(_type-external ...) (generate-temporaries #'(_type ...))])
        (syntax/loc stx
          (begin
-           (splicing-syntax-parameterize 
+           (splicing-syntax-parameterize
             ([current-zmq-fun 'external])
             (define-zmq* [_type-external internal]
-              (_fun _socket _option-name 
+              (_fun _socket _option-name
                     [option-value : (_ptr o _type)]
                     [option-size : (_ptr o _size_t)]
                     -> [err : _int]
@@ -359,7 +359,7 @@
 
 (define-zmq-socket-options
   [socket-option zmq_getsockopt]
-  ([_int64 zero? boolean? 
+  ([_int64 zero? boolean?
            RCVMORE MCAST_LOOP]
    [_int64 (λ (x) x) exact-integer?
            RATE RECOVERY_IVL]
@@ -375,10 +375,10 @@
      (with-syntax ([(_type-external ...) (generate-temporaries #'(_type ...))])
        (syntax/loc stx
          (begin
-           (splicing-syntax-parameterize 
+           (splicing-syntax-parameterize
             ([current-zmq-fun 'external])
             (define-zmq* [_type-external internal]
-              (_fun _socket _option-name 
+              (_fun _socket _option-name
                     [option-value : _type]
                     [option-size : _size_t = (ctype-sizeof _type)]
                     -> [err : _int] -> (unless (zero? err) (zmq-error))))
@@ -514,7 +514,7 @@
  [proc-doc/names
   proxy! (->* (socket/c socket/c) ((or/c socket/c false?)) void)
   ([frontend backend] [(capture #f)])
-  @{An FFY binding for @link["http://api.zeromq.org/3-2:zmq_proxy.html"].
+  @{An FFI binding for @link["http://api.zeromq.org/3-2:zmq_proxy.html"].
    Given two sockets and an optional capture socket, set up a proxy between
    the frontend socket and the backend socket.}])
 


### PR DESCRIPTION
This PR adds a binding to [zmq_proxy](http://api.zeromq.org/3-2:zmq-proxy).  This call is available in version 3.2.x of zmq, and replaces zmq_device.

The API is ...

``` text
procedure
(proxy! frontend backend [capture]) → void
  frontend : socket?
  backend : socket?
  capture : (or/c socket? false?) = #f
```
