### PR TITLE
added the name for the zmq_proxy link

### DIFF
--- a/net/zmq.rkt
+++ b/net/zmq.rkt
@@ -514,7 +514,7 @@
  [proc-doc/names
   proxy! (->* (socket/c socket/c) ((or/c socket/c false?)) void)
   ([frontend backend] [(capture #f)])
-  @{An FFI binding for @link["http://api.zeromq.org/3-2:zmq_proxy.html"].
+  @{An FFI binding for @link["http://api.zeromq.org/3-2:zmq_proxy.html"]{zmq_proxy}.
    Given two sockets and an optional capture socket, set up a proxy between
    the frontend socket and the backend socket.}])
 


### PR DESCRIPTION
This PR adds the name of `zmq_proxy` that was missing from the link in the documentation.
