### PR TITLE
Context and socket helpers

### DIFF
--- a/net/zmq.rkt
+++ b/net/zmq.rkt
@@ -384,7 +384,7 @@
  [proc-doc/names
   call-with-socket (c:-> context? socket-type? (procedure-arity-includes/c 1) void)
  (context socket-type procedure)
-  @{Using the @racket[socket!] procedure, @racket[call-with-socket] creates a socket of a valid @racket[socket-type?] using a previously created context. It passes the socket to a procedure with one argument. On return, it closes the socket using @racket[socket-close!]}])
+  @{Using the @racket[socket] procedure, @racket[call-with-socket] creates a socket of a valid @racket[socket-type?] using a previously created context. It passes the socket to a procedure with one argument. On return, it closes the socket using @racket[socket-close!]}])
 
 (define-syntax (define-zmq-socket-options stx)
   (syntax-case stx ()


### PR DESCRIPTION
I wrote some procedures that I have found helpful in my work.  I thought you might like them too:

``` text
(call-with-socket       context              
        socket-type              
        procedure)      →     void
  context : context?
  socket-type : socket-type?
  procedure : (procedure-arity-includes/c 1)
```

and

``` text
(call-with-context      procedure                
     [  #:io-threads io-threads])       →     void
  procedure : (procedure-arity-includes/c 1)
  io-threads : exact-nonnegative-integer? = 1
```
