### PR TITLE
Use `socket?` consistently in docs.

### DIFF
--- a/net/zmq.rkt
+++ b/net/zmq.rkt
@@ -583,7 +583,7 @@
   (proxy* frontend backend capture))
 (provide/doc
  [proc-doc/names
-  proxy! (->* (socket/c socket/c) ((or/c socket/c false?)) void)
+  proxy! (->* (socket? socket?) ((or/c socket? false?)) void)
   ([frontend backend] [(capture #f)])
   @{An FFI binding for @link["http://api.zeromq.org/3-2:zmq_proxy.html"]{zmq_proxy}.
    Given two sockets and an optional capture socket, set up a proxy between


### PR DESCRIPTION
Fixes some broken links.